### PR TITLE
Resolving Issue #8

### DIFF
--- a/werewolves-and-wanderers.html
+++ b/werewolves-and-wanderers.html
@@ -541,7 +541,7 @@ const ROOMS = [
   [17,0,19,0,0,0],        // room 16 treasury
   [18,16,0,14,0,0],       // room 17 chambermaids' bedroom
   [0,17,0,0,0,0],         // room 18 dressing chamber
-  [9,0,16,0,0,0],         // room 19 lift anteroom
+  [9,0,0,16,0,0],         // room 19 lift anteroom
 ];
 
 const DIR_INDEX = {N:0, S:1, E:2, W:3, U:4, D:5};


### PR DESCRIPTION
Fixed. The lift anteroom (room 19) now correctly shows W as available and E as blocked. The two-way connection is consistent — treasury (room 16) exits east to reach the anteroom, and the anteroom exits west to return to the treasury, matching what the room description says.